### PR TITLE
Refactor basic block

### DIFF
--- a/src/AnimatedSVGBlock.jsx
+++ b/src/AnimatedSVGBlock.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
-import BlockSVGRenderer from './BlockRendererSVG';
+// import BlockSVGRenderer from './BlockRendererSVG';
 import { Spring } from 'react-spring/renderprops';
+import BlockContainer from './BlockContainer';
 
 class AnimatedSVGBlock extends Component {
 
@@ -9,25 +10,18 @@ class AnimatedSVGBlock extends Component {
   }
 
   render() {
-    const hz = this.props.hz > 0 ? this.props.hz : 1;  // default to 1
-    const duration = (1/hz);
+    // const hz = this.props.hz > 0 ? this.props.hz : 1;  // default to 1
+    const duration = 1000;
     const init = this.state && this.state.reset;
-    const to = {
-      red: init ? 0.8 : 0.2,
-      green: init ? 0.8 : 0.2,
-      blue: init ? 0.8 : 1.0,
-      indicatorXOffset: init ? 0 : 100,
-    };
 
     return (
       <Spring
         immediate={init}
-        to={to}
+        to={{
+          progress: init ? 0.0 : 1.0,
+        }}
         from={{
-          red: 0.4,
-          green: 0.4,
-          blue: 0.4,
-          indicatorXOffset: 0,
+          progress: 0.0,
         }}
         config={{
           duration: duration,
@@ -37,16 +31,18 @@ class AnimatedSVGBlock extends Component {
       >
         {(animatedProperties) => {
           const props = {
-            x: 10,
-            y: 10 + (this.props.pos * 20),
-            width: 100,
-            height: 20,
-            indicatorYOffset: 10,
-            indicatorHeight: 20,
+            fromRed: 0.8,
+            toRed: 1.0,
+            fromBlue: 0.8,
+            toBlue: 0.0,
+            fromGreen: 0.8,
+            toGreen: 0.0,
+            pos: this.props.pos,
             ...animatedProperties,
           };
 
-          return <BlockSVGRenderer {...props} />;
+          return <BlockContainer {...props} />;
+          // return <BlockSVGRenderer {...props} />;
         }}
       </Spring>
     );

--- a/src/AnimatedSVGBlock.jsx
+++ b/src/AnimatedSVGBlock.jsx
@@ -1,0 +1,56 @@
+import React, { Component } from 'react';
+import BlockSVGRenderer from './BlockRendererSVG';
+import { Spring } from 'react-spring/renderprops';
+
+class AnimatedSVGBlock extends Component {
+
+  onRest() {
+    this.setState({ reset: !(this.state && this.state.reset) });
+  }
+
+  render() {
+    const hz = this.props.hz > 0 ? this.props.hz : 1;  // default to 1
+    const duration = (1/hz);
+    const init = this.state && this.state.reset;
+    const to = {
+      red: init ? 0.8 : 0.2,
+      green: init ? 0.8 : 0.2,
+      blue: init ? 0.8 : 1.0,
+      indicatorXOffset: init ? 0 : 100,
+    };
+
+    return (
+      <Spring
+        immediate={init}
+        to={to}
+        from={{
+          red: 0.4,
+          green: 0.4,
+          blue: 0.4,
+          indicatorXOffset: 0,
+        }}
+        config={{
+          duration: duration,
+          reset: true,
+        }}
+        onRest={this.onRest.bind(this)}
+      >
+        {(animatedProperties) => {
+          const props = {
+            x: 10,
+            y: 10 + (this.props.pos * 20),
+            width: 100,
+            height: 20,
+            indicatorYOffset: 10,
+            indicatorHeight: 20,
+            ...animatedProperties,
+          };
+
+          return <BlockSVGRenderer {...props} />;
+        }}
+      </Spring>
+    );
+  }
+}
+
+export default AnimatedSVGBlock;

--- a/src/AnimatedSVGBlock.jsx
+++ b/src/AnimatedSVGBlock.jsx
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-// import BlockSVGRenderer from './BlockRendererSVG';
 import { Spring } from 'react-spring/renderprops';
 import BlockContainer from './BlockContainer';
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,24 +1,9 @@
 import React, { Component } from 'react';
-import BlockSVGRenderer from './BlockRendererSVG';
-import { Spring } from 'react-spring/renderprops';
+import AnimatedSVGBlock from './AnimatedSVGBlock';
 import './App.css';
 
 class App extends Component {
-
-  onRest() {
-    this.setState({reset: !(this.state && this.state.reset)});
-  }
-
-
   render() {
-    const init = this.state && this.state.reset;
-    const to = {
-      red: init ? 0.8 : 1.0,
-      green: init ? 0.8 : 0.2,
-      blue: init ? 0.8 : 0.3,
-      indicatorXOffset: init ? 0 : 100,
-    };
-
     return (
       <div className="App" >
         <header className="App-header">
@@ -26,40 +11,14 @@ class App extends Component {
         </header>
         <div className="svg-container" style={{ border: "black", margin: "10px" }}>
           <svg x={10} y={10} height={400} width={500}>
-            <Spring
-              immediate={init}
-              to={to}
-              from={{
-                red: 0.8,
-                green: 0.8,
-                blue: 0.8,
-                indicatorXOffset: 0,
-              }}
-              config={{
-                duration: 500,
-                reset: true,
-              }}
-              onRest={this.onRest.bind(this)}
-            >
-              {(animatedProperties) => {
-                const props = {
-                  x: 10,
-                  y: 10,
-                  width: 100,
-                  height: 20,
-                  indicatorYOffset: 10,
-                  indicatorHeight: 20,
-                  ...animatedProperties,
-                };
-
-                return <BlockSVGRenderer {...props} />;
-              }}
-            </Spring>
+            <AnimatedSVGBlock hz={0.5} pos={0}/>
+            <AnimatedSVGBlock hz={1} pos={1}/>
           </svg>
         </div>
       </div>
     );
   }
 }
+
 
 export default App;

--- a/src/BlockContainer.jsx
+++ b/src/BlockContainer.jsx
@@ -1,0 +1,29 @@
+import React, { Component } from 'react';
+import BlockRendererSVG from './BlockRendererSVG';
+
+class BlockContainer extends Component {
+
+  lerp(from, to, t) {
+    const lerp = t * (to - from) + from;
+    return lerp;
+  }
+
+  render() {
+    return (
+      <BlockRendererSVG
+        x={10}
+        y={10 + this.props.pos * 20}
+        width={100}
+        height={20}
+        indicatorYOffset={10}
+        indicatorHeight={10}
+        indicatorXOffset={100 * this.props.progress}
+        red={this.lerp(this.props.fromRed, this.props.toRed, this.props.progress)}
+        green={this.lerp(this.props.fromGreen, this.props.toGreen, this.props.progress)}
+        blue={this.lerp(this.props.fromBlue, this.props.toBlue, this.props.progress)}
+      />
+    );
+  }
+}
+
+export default BlockContainer;


### PR DESCRIPTION
# Summary
This resolves issue #12. 

This refactor wraps the stateless `BlockRendererSVG` in a container that translates progress (0.0 - 1.0) into `props` consumed by `BlockRendererSVG`s.

![image](https://user-images.githubusercontent.com/11576884/52615002-6b0c4500-2e48-11e9-8758-1fd762412657.png)
 