### PR TITLE
Decouple and Refactor Components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18910,6 +18910,11 @@
         "@babel/runtime": "^7.0.0"
       }
     },
+    "react-uid": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/react-uid/-/react-uid-2.2.0.tgz",
+      "integrity": "sha512-z+g5+hFOQ08hCfrGcJ1PNs+cmvH8Uq2CVzCmPeWBsUi5A4W4NWXR5jouledzy3oSKGMU9HOzf8zFuGi15TXJoQ=="
+    },
     "read-pkg": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "react": "^16.8.1",
     "react-dom": "^16.8.1",
     "react-spring": "^8.0.5",
+    "react-uid": "^2.2.0",
     "uri-js": "^4.2.2",
     "vexflow": "^1.2.87"
   },

--- a/src/AnimatedHarmonyBlock.jsx
+++ b/src/AnimatedHarmonyBlock.jsx
@@ -3,8 +3,9 @@ import { Spring } from 'react-spring/renderprops';
 import BlockContainer from './BlockContainer';
 import ClockContainer from './ClockContainer';
 import CircleContainer from './CircleContainer';
+import StaffRendererSVG from './StaffRendererSVG';
 
-class AnimatedSVGBlock extends Component {
+class AnimatedHarmonyBlock extends Component {
 
   colorForIndex(index) {
 
@@ -35,6 +36,24 @@ class AnimatedSVGBlock extends Component {
 
   onRest() {
     this.setState({ reset: !(this.state && this.state.reset) });
+  }
+
+  getContainerForType(type, props) {
+    let container = null;
+    switch (type) {
+      case "block":
+        container = <BlockContainer {...props} />;
+        break;
+      case "clock":
+        container = <ClockContainer {...props} />;
+        break;
+      case "circle":
+      default:
+        container = <CircleContainer {...props} />;
+        break;
+    }
+
+    return container;
   }
 
   render() {
@@ -71,19 +90,29 @@ class AnimatedSVGBlock extends Component {
             };
 
           });
-          const props = { blocks };
-          return (
-            <g>
-              <BlockContainer {...props} />
-              <ClockContainer {...props} />
-              <CircleContainer {...props} />
-            </g>
-          );
 
+          const chord = this.props.chord;
+          const title = this.props.title;
+          const staff = this.props.chord ?
+            <StaffRendererSVG title={title} chord={chord} /> :
+            null;
+
+          const props = { blocks };
+          const container = this.getContainerForType(this.props.type, props);
+
+          return (
+            <div className="blocks-container">
+              {title}
+              <svg>
+                {staff}
+                {container}
+              </svg>
+            </div>
+          );
         }}
       </Spring>
     );
   }
 }
 
-export default AnimatedSVGBlock;
+export default AnimatedHarmonyBlock;

--- a/src/App.css
+++ b/src/App.css
@@ -23,8 +23,8 @@
 }
 
 .blocks-container {
-  border: 1px dotted;
-
+  border-bottom: 1px dotted;
+  margin-top: 20px;
 }
 
 @keyframes App-logo-spin {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
-import AnimatedSVGBlock from './AnimatedSVGBlock';
-import StaffRendererSVG from './StaffRendererSVG';
+import AnimatedHarmonyBlock from './AnimatedHarmonyBlock';
 import Vex from 'vexflow';
 import './App.css';
 
@@ -28,6 +27,8 @@ class App extends Component {
       duration: "h",
     })];
 
+    const height = 150;
+    const width = 120;
     return (
       <div className="App" >
         <header className="App-header">
@@ -35,31 +36,33 @@ class App extends Component {
         </header>
         <div className="svg-container" style={{ border: "black", margin: "auto", display: "block" }}>
           <div className="blocks-container">
-            <StaffRendererSVG title="Major 3rd" chord={chordM3} />
-            <svg height={300} width={120} margin="10px">
-              <AnimatedSVGBlock hz={[5, 4]} />
-            </svg>
+            Major 3rd
+            <AnimatedHarmonyBlock
+              height={height}
+              width={width}
+              chord={chordM3}
+              type="clock"
+              hz={[5, 4]}
+            />
           </div>
 
           <div className="blocks-container">
-            <StaffRendererSVG title="Perfect 4th" chord={chordP4} />
-            <svg height={300} width={120}>
-              <AnimatedSVGBlock hz={[3, 4]} />
-            </svg>
+            Perfect 4th
+            <AnimatedHarmonyBlock
+              chord={chordP4}
+              type="circle"
+              hz={[3, 4]}
+            />
           </div>
 
           <div className="blocks-container">
-            <StaffRendererSVG title="Perfect 5th" chord={chordP5} />
-            <svg height={300} width={120}>
-              <AnimatedSVGBlock hz={[6, 4]} />
-            </svg>
+            Perfect 5th
+            <AnimatedHarmonyBlock chord={chordP5} type="circle" hz={[6, 4]} />
           </div>
 
           <div className="blocks-container">
-            <StaffRendererSVG title="Octave" chord={chordP8} />
-            <svg height={300} width={120}>
-              <AnimatedSVGBlock hz={[8, 4]} />
-            </svg>
+            Octave
+            <AnimatedHarmonyBlock chord={chordP8} type="circle" hz={[8, 4]} />
           </div>
         </div>
       </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -57,7 +57,7 @@ class App extends Component {
 
           <div className="blocks-container">
             Perfect 5th
-            <AnimatedHarmonyBlock chord={chordP5} type="circle" hz={[6, 4]} />
+            <AnimatedHarmonyBlock chord={chordP5} type="block" hz={[6, 4]} />
           </div>
 
           <div className="blocks-container">

--- a/src/CircleContainer.jsx
+++ b/src/CircleContainer.jsx
@@ -11,7 +11,7 @@ class CircleContainer extends Component {
         <CircleRendererSVG
           key={index}
           x={50}
-          y={250}
+          y={10}
           width={10}
           height={15}
           rotation={360 * progress}

--- a/src/ClockContainer.jsx
+++ b/src/ClockContainer.jsx
@@ -11,9 +11,9 @@ class ClockContainer extends Component {
         <ClockRendererSVG
           key={index}
           x={50}
-          y={100}
+          y={0}
           width={10}
-          height={50}
+          height={30}
           rotation={360 * progress}
           red={Utils.lerp(block.fromRed, block.toRed, progress)}
           green={Utils.lerp(block.fromGreen, block.toGreen, progress)}

--- a/src/ClockRendererSVG.jsx
+++ b/src/ClockRendererSVG.jsx
@@ -12,8 +12,8 @@ class ClockRendererSVG extends Component {
     );
 
     // Lower left
-    const x1 = this.props.x;
-    const y1 = this.props.y + this.props.height;
+    const x1 = this.props.x ? this.props.x : 0;
+    const y1 = (this.props.y ? this.props.y : 0) + this.props.height;
 
     // Lower right
     const x2 = x1 + this.props.width;
@@ -21,7 +21,7 @@ class ClockRendererSVG extends Component {
 
     // Top
     const x3 = x1 + (this.props.width / 2);
-    const y3 = this.props.y
+    const y3 = this.props.y ? this.props.y : 0;
 
     const points = `${x1},${y1} ${x2},${y2} ${x3},${y3}`;
     const transform = `rotate(${this.props.rotation}, ${x3}, ${y1})`;

--- a/src/StaffRendererSVG.jsx
+++ b/src/StaffRendererSVG.jsx
@@ -25,13 +25,7 @@ class StaffRendererSVG extends Component {
   render() {
 
     let svg = this.state ? this.state.svg : null;
-    // svgContainer.style.height = Math.max(100, bb.h + padding) + "px";
-    // svgContainer.style.width = 100 + "px";
-    // svgContainer.style.position = "relative";
-    // svgContainer.style.display = "inlineBlock";
     const bb = this.state ? this.state.bb : null;
-    // const padding = 10;
-    // const half = padding / 2;
     const x = bb ? bb.x : 0;
     const y = bb ? bb.y : 0;
     const top = y;

--- a/src/StaffRendererSVG.jsx
+++ b/src/StaffRendererSVG.jsx
@@ -1,49 +1,59 @@
 import React, { Component } from 'react';
 import Vex from 'vexflow';
+import { uid } from 'react-uid';
 
 const VF = Vex.Flow;
 
-// Reference from : https://gist.github.com/wchargin/96f2550531b67c379b3e
 class StaffRendererSVG extends Component {
+  constructor(props) {
+    super(props);
+
+    this.key = uid(this);
+
+  }
   componentDidMount() {
     const { chord } = this.props;
-    const svgContainer = document.createElement('div');
+    const svgContainer = document.getElementById(this.key);
     const renderer = new VF.Renderer(svgContainer, VF.Renderer.Backends.SVG);
     const ctx = renderer.getContext();
     const stave = new VF.Stave(0, 0, 100);
     stave.addClef('treble').setContext(ctx).draw();
     const bb = VF.Formatter.FormatAndDraw(ctx, stave, chord);
-
-    const svg = svgContainer.childNodes[0];
-    const padding = 10;
-    const half = padding / 2;
-
-    svg.style.top = -bb.y + half + Math.max(0, (100 - bb.h) * 2 / 3) + "px";
-    svg.style.height = Math.max(100, bb.h);
-    svg.style.left = "0px";
-    svg.style.width = 100 + "px";
-    svg.style.position = "absolute";
-    svg.style.overflow = "visible";
-    svgContainer.style.height = Math.max(100, bb.h + padding) + "px";
-    svgContainer.style.width = 100 + "px";
-    svgContainer.style.position = "relative";
-    svgContainer.style.display = "inlineBlock";
-    this.refs.outer.appendChild(svgContainer);
+    this.setState({ bb });
   }
 
   render() {
-    return (
-      <div ref="outer" style={{
-        margin: "auto",
-        width: "100px",
-        padding: 10,
-        borderRadius: 10,
-        display: "inline-float"
-      }} >
-        {this.props.title}
-      </div>
-    );
 
+    let svg = this.state ? this.state.svg : null;
+    // svgContainer.style.height = Math.max(100, bb.h + padding) + "px";
+    // svgContainer.style.width = 100 + "px";
+    // svgContainer.style.position = "relative";
+    // svgContainer.style.display = "inlineBlock";
+    const bb = this.state ? this.state.bb : null;
+    // const padding = 10;
+    // const half = padding / 2;
+    const x = bb ? bb.x : 0;
+    const y = bb ? bb.y : 0;
+    const top = y;
+    const height = bb ? Math.max(200, bb.h) : 0;
+    const left = "0px";
+    const width = 100 + "px";
+
+    const title = this.props.title;
+    return (
+      <svg
+        x={x}
+        y={y}
+        top={top}
+        left={left}
+        width={width}
+        height={height}
+        id={this.key}
+      >
+        <text>{title}</text>
+        {svg}
+      </svg>
+    );
   }
 }
 


### PR DESCRIPTION
# Description
This refactors the `AnimatedSVGBlock ` into `AnimatedHarmonyBlock`. 

## Staff Rendering
`AnimatedHarmonyBlocks` will render a `vexflow` staff for the notes provided on the `props.chord` property.

## Single Visualization Rendering
Each `AnimatedHarmonyBlock` renders a single animation instead determined by `props.type`

## Restructuring rendering work
Moved around responsibilities for who draws divs and who draws svg elements. Only low level components should emit `svg`. Unless directly rendering, Components should return html.

![image](https://user-images.githubusercontent.com/11576884/52996521-bb4c4f80-33d2-11e9-9cc3-4dc1071736a4.png)
