### PR TITLE
Implement Circle Rotation in GLSL

### DIFF
--- a/src/Circle.glsl
+++ b/src/Circle.glsl
@@ -10,15 +10,27 @@ uniform float u_time;
 #define PI 3.141592653589793
 #define TWO_PI 6.283185307179586
 
-vec3 circle(in vec2 st, in float radius){
-  vec3 color = vec3(.2, .2, .9);
-  vec2 center = vec2(.5, .5);
-  float dist = distance(st, center);
-  return color - step(radius, dist);
+mat2 rotate2D(in float _angle){
+  return mat2(cos(_angle),
+  -sin(_angle),
+  sin(_angle),
+  cos(_angle));
+}
+
+vec3 circle(in vec2 st,in float radius){
+  vec3 color=vec3(.2,.2,.9);
+  vec2 rxy=vec2(.5,.6);
+  vec2 cxy=vec2(.5,.5);
+  float speed = 10.0;
+  st=st-rxy;
+  st=rotate2D(-u_time * speed)*st;
+  st+=rxy;
+  float dist=distance(st,cxy);
+  return color-step(radius,dist);
 }
 
 void main(){
-  vec2 st = gl_FragCoord.xy / u_resolution.xy;
-  vec3 color = circle(st,.1);
-  gl_FragColor = vec4(color,1.0);
+  vec2 st=gl_FragCoord.xy/u_resolution.xy;
+  vec3 color=circle(st,.1);
+  gl_FragColor=vec4(color,1.);
 }

--- a/src/Circle.glsl
+++ b/src/Circle.glsl
@@ -12,7 +12,7 @@ uniform float u_time;
 
 float circle(in vec2 st, in float radius){
   vec2 center = vec2(.5, .5);
-  float dist = distance(st, center); 
+  float dist = distance(st, center);
   return 1. - step(radius, dist);
 }
 

--- a/src/Circle.glsl
+++ b/src/Circle.glsl
@@ -10,14 +10,15 @@ uniform float u_time;
 #define PI 3.141592653589793
 #define TWO_PI 6.283185307179586
 
-float circle(in vec2 st, in float radius){
+vec3 circle(in vec2 st, in float radius){
+  vec3 color = vec3(.2, .2, .9);
   vec2 center = vec2(.5, .5);
   float dist = distance(st, center);
-  return 1. - step(radius, dist);
+  return color - step(radius, dist);
 }
 
 void main(){
   vec2 st = gl_FragCoord.xy / u_resolution.xy;
-  vec3 color = vec3(circle(st,.1));
-  gl_FragColor = vec4(color,0.9);
+  vec3 color = circle(st,.1);
+  gl_FragColor = vec4(color,1.0);
 }

--- a/src/Circle.glsl
+++ b/src/Circle.glsl
@@ -10,15 +10,14 @@ uniform float u_time;
 #define PI 3.141592653589793
 #define TWO_PI 6.283185307179586
 
-float circle(in vec2 _st,in float _radius){
-  vec2 dist=_st-vec2(.5);
-  return 1.-smoothstep(_radius-(_radius*.01),
-  _radius+(_radius*.01),
-  dot(dist,dist)*4.);
+float circle(in vec2 st, in float radius){
+  vec2 center = vec2(.5, .5);
+  float dist = distance(st, center); 
+  return 1. - step(radius, dist);
 }
 
 void main(){
-  vec2 st=gl_FragCoord.xy/u_resolution.xy;
-  vec3 color=vec3(circle(st,.3));
-  gl_FragColor=vec4(color,1.);
+  vec2 st = gl_FragCoord.xy / u_resolution.xy;
+  vec3 color = vec3(circle(st,.1));
+  gl_FragColor = vec4(color,0.9);
 }

--- a/src/CircleRendererGL.jsx
+++ b/src/CircleRendererGL.jsx
@@ -18,10 +18,13 @@ class CircleRendererGL extends Component {
       });
 
       node =
-        <Surface width={200} height={100}>
+        <Surface width={100} height={100}>
           <Node
             shader={shaders.circle}
-            uniforms={{ u_resolution: [200, 200] }}
+            uniforms={{
+              u_resolution: [100, 100],
+              u_time: this.props.blocks[0].progress,
+            }}
           />
         </Surface>
     }


### PR DESCRIPTION
# Description 
This introduces the following enhancements to the GLSL implementation of harmony blocks:

## Progress from React
The `u_time` shader uniform is now populated by looking at the progress amount on the `this.props.block[0].progress`. Later, multiple blocks and each of their progresses can be supported.

## Circle Rotation about a point
The `Circle.glsl` now renders a circle that rotates about a point given by the value in `u_time.`

Later, the size, color and rotational parameters will be passed in.

![image](https://user-images.githubusercontent.com/11576884/53295104-0edee480-37a9-11e9-95ba-c3787d577a90.png)
