### PR TITLE
Render multiple harmony circles in GLSL

### DIFF
--- a/src/Circle.glsl
+++ b/src/Circle.glsl
@@ -4,7 +4,7 @@ precision mediump float;
 
 uniform vec2 u_resolution;
 uniform vec2 u_mouse;
-uniform float u_time;
+uniform vec2 u_frequencies;
 
 #define PI_TWO 1.570796326794897
 #define PI 3.141592653589793
@@ -17,13 +17,11 @@ mat2 rotate2D(in float _angle){
   cos(_angle));
 }
 
-vec3 circle(in vec2 st,in float radius){
-  vec3 color=vec3(.2,.2,.9);
+vec3 circle(in vec2 st,in float radius,in vec3 color, in float progress){
   vec2 rxy=vec2(.5,.6);
   vec2 cxy=vec2(.5,.5);
-  float speed = 10.0;
-  st=st-rxy;
-  st=rotate2D(-u_time * speed)*st;
+  st-=rxy;
+  st=rotate2D(-progress * TWO_PI)*st;
   st+=rxy;
   float dist=distance(st,cxy);
   return color-step(radius,dist);
@@ -31,6 +29,8 @@ vec3 circle(in vec2 st,in float radius){
 
 void main(){
   vec2 st=gl_FragCoord.xy/u_resolution.xy;
-  vec3 color=circle(st,.1);
+  vec3 c1=circle(st,.1,vec3(.2,.2,.9),u_frequencies.x);
+  vec3 c2=circle(st,.1,vec3(.9,.2,.2),u_frequencies.y);
+  vec3 color=max(c1,c2);
   gl_FragColor=vec4(color,1.);
 }

--- a/src/CircleRendererGL.jsx
+++ b/src/CircleRendererGL.jsx
@@ -23,7 +23,8 @@ class CircleRendererGL extends Component {
             shader={shaders.circle}
             uniforms={{
               u_resolution: [100, 100],
-              u_time: this.props.blocks[0].progress,
+              u_frequencies: [this.props.blocks[0].progress,
+                              this.props.blocks[1].progress],
             }}
           />
         </Surface>


### PR DESCRIPTION
# Description
This change updates the Circle shader to take in multiple 'progress' entries which are used to animate multiple circles. 

Now, each of the ratios on the main page can be visualized as hardware-accelerated circles.
![image](https://user-images.githubusercontent.com/11576884/53315161-c2fa7100-3876-11e9-8e20-c17d4758664c.png)
